### PR TITLE
README: @philips move from CoreOS to Red Hat

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Term ends in October 2019, positions to permanently close to leave final committ
 | Brian Grant | @bgrant0607 | Google | 2y | 
 | Tim Hockin | @thockin | Google | 2y |  
 | Sarah Novotny | @sarahnovotny | Google | 2y |
-| Brandon Philips | @philips | CoreOS | 2y | 
+| Brandon Philips | @philips | Red Hat | 2y | 
 
 ## Meetings
 


### PR DESCRIPTION
CoreOS was acquired by Red Hat in Jan 2018. Update my affiliation.