### PR TITLE
thockin steps down from steering

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,5 +13,4 @@ aliases:
     - sarahnovotny
     - smarterclayton
     - spiffxp
-    - thockin
     - timothysc

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the [Steering Committee Charter](charter.md) for specific committee structur
 
 | Name | Profile | Affiliation | Term Length |
 | ---- | ------- | ----------- | ----------- | 
-| Aaron Crickenberger | @spiffxp | Samsung SDS | 1y | 
+| Aaron Crickenberger | @spiffxp | Google | 1y | 
 | Quinton Hoole | @quinton-hoole | Huawei R&D | 1y | 
 | Timothy St. Clair | @timothysc | Heptio | 1y | 
 
@@ -30,9 +30,14 @@ Term ends in October 2019, positions to permanently close to leave final committ
 | Brendan Burns | @brendandburns | Microsoft | 2y |
 | Clayton Coleman | @smarterclayton | Red Hat | 2y |
 | Brian Grant | @bgrant0607 | Google | 2y | 
-| Tim Hockin | @thockin | Google | 2y |  
 | Sarah Novotny | @sarahnovotny | Google | 2y |
 | Brandon Philips | @philips | Red Hat | 2y | 
+
+### Emeritus
+
+| Name | Profile |
+| ---- | ------- |
+| Tim Hockin | @thockin |
 
 ## Meetings
 


### PR DESCRIPTION
Since Aaron has joined Google, we are over-represented.  I hereby step
down from the kubernetes steering committee.

Thanks for all the fish.