### PR TITLE
Move values.md from steering to the community repo

### DIFF
--- a/values.md
+++ b/values.md
@@ -1,27 +1,4 @@
-# Kubernetes Community Values
-
-Kubernetes Community culture is frequently cited as a substantial contributor to the meteoric rise of this Open Source project.  Below are the distilled values which have evolved over the last many years in our community pushing our project and peers toward constant improvement.
-
-## Distribution is better than centralization
-
-The scale of the Kubernetes project is only viable through high-trust and high-visibility distribution of work, which includes delegation of authority, decision making, technical design, code ownership, and documentation.  Distributed asynchronous ownership, collaboration, communication and decision making are the cornerstone of our world-wide community.
-
-## Community over product or company
-
-We are here as a community first, our allegiance is to the intentional stewardship of the Kubernetes project for the benefit of all its members and users everywhere.  We support working together publicly for the common goal of a vibrant interoperable ecosystem providing an excellent experience for our users. Individuals gain status through work, companies gain status through their commitments to support this community and fund the resources necessary for the project  to operate.
-
-## Automation over process
-
-Large projects have a lot of less exciting, yet, hard work.  We value time spent automating repetitive work more highly than toil. Where that work cannot be automated, it is our culture to recognize and reward all types of contributions. However, heroism is not sustainable.
-
-## Inclusive is better than exclusive
-
-Broadly successful and useful technology requires different perspectives and skill sets which can only be heard in a welcoming and respectful environment.  Community membership is a privilege, not a right. Community Leadership is earned through effort, scope, quality, quantity, and duration of contributions. Our community shows respect for the time and effort put into a discussion regardless of where a contributor is on their growth path.
-
-## Evolution is better than stagnation
-
-Openness to new ideas and studied technological evolution make Kubernetes a stronger project.  Continual improvement, servant leadership, mentorship and respect are the foundations of the Kubernetes project culture. It is the duty for leaders in the Kubernetes community to find, sponsor, and promote new community members. Leaders should expect to step aside. Community members should expect to step up.
-
-**"Culture eats strategy for breakfast."   --Peter Drucker**
-
-
+This file has moved to https://git.k8s.io/community/values.md
+<!--
+This file is a placeholder to preserve links.
+-->


### PR DESCRIPTION
This PR removes `values.md` from the steering repo and https://github.com/kubernetes/community/pull/3103 adds it to the community repo.

Since this document talks about community values, it seems apt to place it in the "kubernetes/community" repo and have it be more discoverable.

/cc @dims @spiffxp @sarahnovotny @parispittman @cblecker 

/sig contributor-experience
/committee steering
/hold