### PR TITLE
Remove the values.md tombstone file

### DIFF
--- a/values.md
+++ b/values.md
@@ -1,4 +1,0 @@
-This file has moved to https://git.k8s.io/community/values.md
-<!--
-This file is a placeholder to preserve links.
--->


### PR DESCRIPTION
The original content was moved to the [community repo](https://github.com/kubernetes/community/blob/master/values.md) in January in https://github.com/kubernetes/steering/commit/412bdfae0af980f3b1aec05737421b6c57910b1d, which is almost three months ago now.

Additionally, all references pointing to this file now point to the file in the community repo: https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-incubator+org%3Akubernetes-csi+org%3Akubernetes-client+%22values.md%22&type=Code

Edit: except in old blog posts, created https://github.com/kubernetes/website/pull/13954 for it.

/cc @spiffxp @dims 