### PR TITLE
Initial draft for travel sponsorship

### DIFF
--- a/travel-sponsorship.md
+++ b/travel-sponsorship.md
@@ -1,0 +1,82 @@
+# Kubernetes Contributor Travel Fund
+
+## Purpose
+
+To establish and administer a fund for members of the Kubernetes upstream contributor community to travel and particiate in KubeCon/CloudNativeCon.
+
+## Requirements
+
+ - Candidates must be a [member of the Kubernetes GitHub organization][membership] or working towards it. Exceptions: TODO
+ - Those requesting funds must indicate that they do not have funding available from another source, such as an employer or the event itself that might cover costs for presenters.
+
+## Process
+
+Submit an issue to a Kubernetes Travel Fund Issue-Only repository. 
+Your issue will go into a private repository where only TODO: $certain_group can see your information due to privacy.
+
+Requests must be made three months before the event. Requests submitted after that will not be approved.
+
+It is strongly recommended that you submit your request far enough in advance to get approval before making relevant expenditures.
+Review of requests will take at least 72 hours and may take considerably longer. Note, with limited funds available, approval is not guaranteed.
+
+### Visa Tips
+
+For all events, it is recommended to apply for a visa at least 6 months prior.
+
+### Requesting Travel Funds
+
+Open an issue template, the results go to a private repo that only TODO: $certain_group of people can see.
+        
+You'll be asked:
+ - Your Name
+ - The name of the event you plan to attend.
+ - The location, dates of the event and where you will be traveling from.
+ - The presentation you intend to give, if applicable.
+ - The size of the stipend you wish to receive.
+
+### Approval
+
+A request is approved when all of the following criteria are met:
+
+- The request has approval from at least two members of the TODO:$certain_group
+- No members of TODO: $certain_group objected to the request.
+- The issue has been closed.
+
+An appointed treasurer from the TODO: $certain_group will liaise with a member of CNCF on a regular basis to review the status of the travel fund. 
+In the event that any pending requests might not be approved because of available funds, a separate issue will be raised. 
+Generally speaking, however, members shouldn't need to worry about the status of the fund itself.
+
+### Considerations for approval of a request
+
+If there are too many requests for the limited funds, we will measure the following:
+
+#### Impact
+
+Preference is given to speakers, panelists, and those volunteering onsite at the conference.
+How much you contribute to the project.
+
+#### Outreach
+
+Preference is given to underserved communities.
+
+#### Cost
+
+The larger the stipend the more critically the travel fund admins will consider the request and application.
+The budget for this program is a finite resource.
+
+#### Equity
+
+Preference is given to individuals who cannot receive travel funding from their employers or individuals who have not previously received a stipend.
+
+### Social Post
+
+After the trip, participants are encouraged to write up a blog post or use similar social media to share their experiences with the community. This step is optional.
+
+## 2019 Allocation
+
+The request from Technical Steering Committee and the Community Committee for a 2019 joint travel fund
+was approved in the amount of TODO: $xx
+
+Please direct any questions or concerns about the travel fund to `contributors@kubernetes.io`
+
+[membership]: https://git.k8s.io/community/community-membership.md

--- a/travel-sponsorship.md
+++ b/travel-sponsorship.md
@@ -12,9 +12,6 @@ To establish and administer a fund for members of the Kubernetes upstream contri
 
 ## Process
 
-Submit an issue to a Kubernetes Travel Fund Issue-Only repository. 
-Your issue will go into a private repository where only TODO: $certain_group can see your information due to privacy.
-
 Requests must be made at least three months before the event. For large events the travel fund coordinators may set a deadline ahead off time for requests. Requests submitted after that will not be approved.
 
 It is strongly recommended that you submit your request far enough in advance to get approval before making relevant expenditures.
@@ -26,7 +23,8 @@ For all events, it is recommended to apply for a visa at least 6 months prior.
 
 ### Requesting Travel Funds
 
-Open an issue template, the results go to a private repo that only TODO: $certain_group of people can see.
+Fill out a request in the TODO: travel form. 
+Your application will only be visible to TODO: $certain_group due to privacy.
         
 You'll be asked:
  - Your Name

--- a/travel-sponsorship.md
+++ b/travel-sponsorship.md
@@ -6,15 +6,16 @@ To establish and administer a fund for members of the Kubernetes upstream contri
 
 ## Requirements
 
- - Candidates must be a [member of the Kubernetes GitHub organization][membership] or working towards it. Exceptions: TODO
+ - Candidates must be a [member of the Kubernetes GitHub organization][membership] or working towards it. Exceptions may be granted at the discretion of the steering committee. 
  - Those requesting funds must indicate that they do not have funding available from another source, such as an employer or the event itself that might cover costs for presenters.
+ - Candidates may request partial funding for a specific purpose, for example "hotel only" or some other part of a trip. 
 
 ## Process
 
 Submit an issue to a Kubernetes Travel Fund Issue-Only repository. 
 Your issue will go into a private repository where only TODO: $certain_group can see your information due to privacy.
 
-Requests must be made three months before the event. Requests submitted after that will not be approved.
+Requests must be made at least three months before the event. For large events the travel fund coordinators may set a deadline ahead off time for requests. Requests submitted after that will not be approved.
 
 It is strongly recommended that you submit your request far enough in advance to get approval before making relevant expenditures.
 Review of requests will take at least 72 hours and may take considerably longer. Note, with limited funds available, approval is not guaranteed.
@@ -33,6 +34,7 @@ You'll be asked:
  - The location, dates of the event and where you will be traveling from.
  - The presentation you intend to give, if applicable.
  - The size of the stipend you wish to receive.
+   - The stipend could be used for meals, travel expenses, and other conference-related expenses. It should NOT be used as personal spending money. 
 
 ### Approval
 
@@ -74,8 +76,7 @@ After the trip, participants are encouraged to write up a blog post or use simil
 
 ## 2019 Allocation
 
-The request from Technical Steering Committee and the Community Committee for a 2019 joint travel fund
-was approved in the amount of TODO: $xx
+The request from Technical Steering Committee and the Community Committee for a 2019 joint travel fund was approved in the amount of TODO: $xx
 
 Please direct any questions or concerns about the travel fund to `contributors@kubernetes.io`
 


### PR DESCRIPTION
This is a PR of Paris' draft. I've added TODOs in the sections that need it, and did some minor edits. Some things steering might also want to consider:

- We should consider revising SIG/committee/WG/UG governance to include seeding and recommending people for this program as we shouldn't expect individuals to just find it, SIGs should know that they should be on the lookout for people who might need this program. 

- The equity section is written to ensure new people are sponsored, perhaps also explictly consider people who are repeat high-performers who show consistent contributions? 


I will be pushing editing updates as steering gives feedback so I'll be pushing little fixes often. 

/hold
