### PR TITLE
adding: bosun, engagement,& fixing typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,11 @@
-# Contributing to the steering repo
+# Contributing to Steering  
+This repo and the committee itself   
 
-This repo is for the use of the steering committee to organize itself and record decisions and processes.
+This repo is for the use of the steering committee to organize itself and record
+ decisions and processes.
 
-The right mode to contribute depends on the type of change that you are proposing.
-
-# Non-members
-
-Submit a PR and then send email to steering@kubernetes.io.
-To communicatie sensitive items with the steering committee privately, send an email to steering-private@kubernetes.io.
+The right mode to contribute depends on the type of change that you are
+proposing or engagement level you are seeking with the committee.
 
 # Steering Committee Members
 
@@ -28,3 +26,23 @@ If it is clear that there is no disagreement feel free to self merge.
 Create a PR.
 Discuss at length and have decisions ratified by the larger group.
 Ensure there is live discussion by a quorum of members.
+
+# Non-members
+
+- Open an issue in this repo and follow up an email to steering@kubernetes.io.
+We do watch the repo but this gives us a better heads up to prepare in case we
+need to find or ask for more information.  
+- If you need guidance (example: SIG Chairs, funding*) or have a governance
+discussion topic, please join us at our monthly public meeting! By joining the
+mailing list, you'll also get the calendar invite. Check our [README] to get the
+ info, too.
+  - In order for us to best serve you, please email us steering@kubernetes.io
+  with the topic you'd like to address, supporting documentation and context,
+  the solution you are seeking (if known) and what month you'd like to visit.
+- To communicate sensitive items with the steering committee privately, send an
+email to steering-private@kubernetes.io.
+
+*all funding inquires should start here -> https://github.com/kubernetes/funding 
+
+
+[README]: ./README.md

--- a/bosun.md
+++ b/bosun.md
@@ -1,0 +1,68 @@
+# Steering Committee Bosun Guide  
+
+This doc is a guide to help the delegated Steering Committee (SC) Member bosun
+the public meeting. SC members will pick a new one for the next meeting at the
+end.  
+
+## Before
+1. Create the skeleton meeting agenda from follow up items the meeting prior,
+parking lot topics at the top, and ask other steering members to populate.
+2. Read through the agenda just to familiarize yourself with the content to
+assign timeboxes. [repeat a few times in the days leading to the meeting if it’s
+ a live agenda]
+3. Post the draft agenda at least 3 business days before with a call for final topics and
+ a clear timebox to the kubernetes-dev and steering mailing lists. This will act as a reminder
+  and put the agenda on the community’s radar, too. Ideally this would be Wednesday before the meeting and closing the agenda by Friday to give time for everyone to prepare.  
+  - Note that the dev mailing list is the source of truth. While a Slack
+notification is nice and helpful, the mailing list is the main communication
+channel.
+  - Also post to the #steering-committee, #kubernetes-dev, #chairs-and-techleads
+slack channels
+6. Make sure there’s someone who volunteers from contribex to act as the meeting
+ host to mute folks, verify recording, note taker and other zoom admin tasks.
+7. If no one steps up for note taking, you’re it.
+8. Do we want to poll the attendees with any questions? Do we want to take any
+live community voting for pulse checks? (not decisions)
+9. DAY OF: Join ten minutes early to make sure all audio, video, and zoom
+administration (including capability to record) is right. You'll need the zoom host key at the very least and to record to the cloud.  
+10. Make sure that you have cleared your desktop and can be prepared to present
+if needed. Sometimes AV problems will require you to step in and present.
+
+## During
+### Starting:
+1. Before recording the meeting, tell the group “This is a Kubernetes meeting
+that will be posted publicly on YouTube, so please be mindful that what you say
+is being recorded.
+2. Please also mute if you are not speaking.” Talk about the process of waiting
+for n Steering members to arrive before you start. Check on [quorum]
+3. Call on others to add things to the agenda and start recording
+#### After recording starts:
+1. Hello! Welcome! [introduce yourself]
+2. Mention that we have a Code of Conduct, so be excellent to each other.
+3. Ask for a note-taker if you don't have one, ask steering members to put
+[steering] in their zoom display name for easy counting.
+4. Keep an eye for questions in the Zoom chat.
+5. Discuss that we may ask for further context, docs, etc. so that we can better
+ understand larger issues or items. If there is a case where we don’t have
+ enough or not prepared, we will set up a separate meeting, bump to the mailing
+ list for further conversation, or bump to a next meeting.
+### Mid-meeting:
+1. Start with current steering projects in flight / stand up with steering folks
+2. Go into specific agenda topics
+3. If space, go through the open issues and PRs and do triage. Make sure everything is assigned and labeled in a  milestone that is either in the next two-month cycle or a future cycles milestone.  
+
+## Ending:
+1. At end, notify everyone the notes will be posted soon to the steering mailing list.
+"Take some time to update the agenda or comment before I send it."
+2. Pick the next bosun.  
+3. Thank everyone for their time.  
+
+## After:
+
+- Clean up any parts of the agenda that got mis-formatted during the meeting.
+- Set any issues and assign owners that arise from the meeting that was not covered in a triage session at the end  
+- Reply to yourself on the mailing list with in-line of the notes. Also announce
+ who will be hosting next month.
+
+
+[quorum]: ./charter.md#quorum

--- a/changes.md
+++ b/changes.md
@@ -4,15 +4,15 @@ At any time, a steering committee member may propose a governance change for
 how the committee itself operates (e.g. charter, election process, etc.).  
 This should be used sparingly, if ever, and in the presence of clear failures
 of the existing process. This process is intended to cover significant changes
-versus small tweaks.  The steering committee does not allocate a role for 
-the broader community in reformulating governance.  The steering commitee believes
+versus small tweaks.  The steering committee does not allocate a role for
+the broader community in reformulating governance.  The steering committee believes
 that in the presence of clear failures, the community will "vote with their feet"
 by either leaving or forking the project.
 
 To propose a change, the following process shall be followed:
 
 * Post a pull request to this repository describing the change.
-* Send a notice to steering@k8s.io annoucing the proposed change.
+* Send a notice to steering@k8s.io announcing the proposed change.
 * If there is no protest after 4 weeks, the change is accepted.
 * At any time prior to acceptance, a steering committee member may call a vote.
 A vote is scheduled no later than 4 weeks after initial introduction of the change.


### PR DESCRIPTION
3 changes here:
-adding a bosun guide from conversations @ meetings to help us streamline and engage better with the community
-adding a few more lines in our CONTRIBUTING doc that folks can contribute to us/engage (not just the repo) until we can get a better engagement doc together. 
-typo fix in an unrelated doc that was glaring in my eye