### PR TITLE
Document zoom admins for steering account

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ We have two meetings every month.
 ## Projects
 
 - [Charter](charter.md)
-- [Backlog](https://github.com/kubernetes/steering/projects/1)
+- [Backlog](https://github.com/orgs/kubernetes/projects/40)
+
+## Contact
+
+If you need the steering committee please email the list steering@kubernetes.io ([archive](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering))
+or reach out in [#steering-committee](https://kubernetes.slack.com/messages/steering-committee) on Slack.
 
 ## CNCF Representative
 
@@ -88,8 +93,3 @@ However, all Steering Committee members have access to the zoom host key.
 | Aaron Crickenberger | **[@spiffxp](https://github.com/spiffxp)** |
 | Christoph Blecker | **[@cblecker](https://github.com/cblecker)** |
 | Paris Pittman | **[@parispittman](https://github.com/parispittman)** |
-
-## Contact
-
-If you need the steering committee please email the list steering@kubernetes.io ([archive](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering))
-or reach out in [#steering-committee](https://kubernetes.slack.com/messages/steering-committee) on Slack.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ The steering committee delegates ownership of various Kubernetes community accou
 | sc2@kubernetes.io | Paris Pittman |
 | sc3@kubernetes.io | Aaron Crickenberger |
 
+## Zoom Admins
+
+The following committee members have zoom credentials for the `steering-private@kubernetes.io` account.
+However, all Steering Committee members have access to the zoom host key.
+
+| Name | Profile |
+| ---- | ------- |
+| Aaron Crickenberger | **[@spiffxp](https://github.com/spiffxp)** |
+| Christoph Blecker | **[@cblecker](https://github.com/cblecker)** |
+| Paris Pittman | **[@parispittman](https://github.com/parispittman)** |
+
 ## Contact
 
 If you need the steering committee please email the list steering@kubernetes.io ([archive](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering))

--- a/onboarding.md
+++ b/onboarding.md
@@ -25,8 +25,10 @@ members and off-board emeritus members.
 - [ ] If a GSuite [top-level account] is owned by an emeritus member,
   transfer it to an existing member.
 
-- [ ] If Zoom license credentials were owned by a majority of emeritus
-  members, share them with exisiting members.
+- [ ] If [Zoom license credentials] were owned by a majority of emeritus
+  members, share them with exisiting members. The Zoom host key is
+  accessible to all members and is a pinned message in the `steering-private`
+  slack channel.
 
 - [ ] Set up a private meeting to go over backlog.
 
@@ -40,3 +42,4 @@ members and off-board emeritus members.
 [kubernetes/k8s.io]: https://github.com/kubernetes/k8s.io
 [cncf-kubernetes-maintainers]: https://lists.cncf.io/g/cncf-kubernetes-maintainers
 [top-level account]: /README.md#top-level-accounts
+[Zoom license credentials]: /README.md#zoom-admins


### PR DESCRIPTION
@lachie83 brought this up recently and I realized that we don't have this documented. :)

This PR also:

- Moves the `Contact` section to be more discoverable
- Updates the steering committee project board link

/assign @parispittman 