### PR TITLE
Move CNCF Service Desk info from community repo

### DIFF
--- a/service-desk.md
+++ b/service-desk.md
@@ -1,0 +1,22 @@
+# CNCF Service Desk
+
+Members of the Steering Committee, root [OWNERS](https://git.k8s.io/community/OWNERS)
+in the kubernetes/community repo and SIG Release leads have access to file tickets
+with the [CNCF Service Desk](https://github.com/cncf/servicedesk)
+on behalf of the Kubernetes project.
+
+The individuals who currently have access are listed below.
+
+| Name | GitHub Profile |
+| ---- | ------- |
+| Aaron Crickenberger | **[@spiffxp](https://github.com/spiffxp)** |
+| Bob Killen | **[@mrbobbytables](https://github.com/mrbobbytables)** |
+| Christoph Blecker | **[@cblecker](https://github.com/cblecker)** |
+| Davanum Srinivas | **[@dims](https://github.com/dims)** |
+| Derek Carr | **[@derekwaynecarr](https://github.com/derekwaynecarr)** |
+| Jorge Castro | **[@castrojo](https://github.com/castrojo)** |
+| Lachlan Evenson | **[@lachie83](https://github.com/lachie83)** |
+| Nikhita Raghunath | **[@nikhita](https://github.com/nikhita)** |
+| Paris Pittman | **[@parispittman](https://github.com/parispittman)** |
+| Stephen Augustus | **[@justaugustus](https://github.com/justaugustus)** |
+| Tim Pepper | **[@tpepper](https://github.com/tpepper)** |


### PR DESCRIPTION
The list of individuals who currently have access to the CNCF Service
Desk is moved from the community repo to the steering repo since it is
more relevant here.

https://github.com/kubernetes/community/pull/4804 removes it from the community repo.

/assign @mrbobbytables @lachie83 