### PR TITLE
Update LF course for inclusive training

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -65,8 +65,8 @@ are able to proceed with a meeting.
 
 ## Inclusive Leadership Training
 
-Members of the committee must take an inclusive speaker training
-[course](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/)
+Members of the committee must take an
+[Inclusive Open Source Community Orientation course](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)
 in support of our community values.  Members are required to report
 completion of the course as part of on-boarding within 30 days from
 the date of their appointment.


### PR DESCRIPTION
Ref: https://lists.cncf.io/g/cncf-toc/topic/78231677#5503, https://github.com/cncf/toc/pull/570

LF has launched a new course for inclusive training in an open source
context - https://training.linuxfoundation.org/announcements/linux-foundation-and-ncwit-release-free-training-course-on-diversity-in-open-source/

All CNCF maintainers will also be required to take this course.

/hold
steering review

cc @kubernetes/steering-committee 