### PR TITLE
Update service desk policy

### DIFF
--- a/service-desk.md
+++ b/service-desk.md
@@ -1,21 +1,13 @@
 # CNCF Service Desk
 
-Members of the Steering Committee, root [OWNERS](https://git.k8s.io/community/OWNERS)
-in the kubernetes/community repo and SIG Release leads have access to file tickets
-with the [CNCF Service Desk](https://github.com/cncf/servicedesk)
-on behalf of the Kubernetes project.
+[Members of the Steering Committee], and the leads of the listed community
+groups below may access or file tickets with the [CNCF Service Desk] on behalf
+of the Kubernetes project.
 
-The individuals who currently have access are listed below.
+**Community Groups:**
+- [SIG Contributor Experience](https://git.k8s.io/community/sig-contributor-experience#leadership)
+- [SIG Release](https://git.k8s.io/community/sig-release#leadership)
 
-| Name | GitHub Profile |
-| ---- | ------- |
-| Alison Dowdney | **[@alisondy](https://github.com/alisondy)** |
-| Bob Killen | **[@mrbobbytables](https://github.com/mrbobbytables)** |
-| Christoph Blecker | **[@cblecker](https://github.com/cblecker)** |
-| Davanum Srinivas | **[@dims](https://github.com/dims)** |
-| Derek Carr | **[@derekwaynecarr](https://github.com/derekwaynecarr)** |
-| Jordan Liggitt | **[@liggitt](https://github.com/liggitt)** |
-| Nikhita Raghunath | **[@nikhita](https://github.com/nikhita)** |
-| Paris Pittman | **[@parispittman](https://github.com/parispittman)** |
-| Stephen Augustus | **[@justaugustus](https://github.com/justaugustus)** |
-| Tim Pepper | **[@tpepper](https://github.com/tpepper)** |
+
+[Members of the Steering Committee]: https://git.k8s.io/community/committee-steering#leadership
+[CNCF Service Desk]: https://github.com/cncf/servicedesk


### PR DESCRIPTION
Moves service desk access from named individuals + k/community owners to specific community group leadership.

Fixes: https://github.com/kubernetes/steering/issues/196

NOTE: A follow up item, the leads from WG-K8s-Infra would like access to the service desk. (ref: https://github.com/kubernetes/steering/pull/195#discussion_r568234580)