### PR TITLE
README.md: Update references to operations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ There are various cases when the Steering Committee may require interactions wit
 | Ihor Dvoretskyi | **[@idvoretskyi](https://github.com/idvoretskyi)** |
 
 For more details on the relationship between Steering and CNCF, please see a
-dedicated document [Relationship with the CNCF](cncf-and-k8s.md).
+dedicated document [Relationship with the CNCF](operations/cncf-and-k8s.md).
 
 ### CNCF ServiceDesk access
 
-The CNCF ServiceDesk policy for Kubernetes community is defined at [ServiceDesk](service-desk.md).
+The CNCF ServiceDesk policy for Kubernetes community is defined at [ServiceDesk](operations/service-desk.md).
 
 ## Top-level Accounts
 


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/steering/pull/233 updating reference links to ops docs.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @parispittman @cblecker @liggitt 