### PR TITLE
Adding missing newline

### DIFF
--- a/elections.md
+++ b/elections.md
@@ -132,7 +132,7 @@ History of election officers:
 2019: mrbobbytables, castrojo, idvoretskyi  
 2020: jberkus, jdumars, idvoretskyi    
 2021: jberkus, alisondy, coderanger  
-2022: coderanger, kaslin, dims
+2022: coderanger, kaslin, dims  
 2023: kaslin, dims, bridgetkromhout
 
 ### Vacancies


### PR DESCRIPTION
Adding the newline as used on the other lines, to fix this problem of 2022 and 2023 being on the same line:

![image](https://github.com/kubernetes/steering/assets/2104453/19850a33-d829-4df8-b48b-9f9ae300b61b)


