### PR TITLE
Update Steering members following annual election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,9 +3,9 @@
 aliases:
   steering-committee:
     - BenTheElder
-    - cblecker
-    - cpanato
     - justaugustus
     - mrbobbytables
+    - pacoxu
     - palnabarun
-    - tpepper
+    - pohly
+    - soltysh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ The Steering Committee is a 7 member body, overseeing the governance of the
 Kubernetes project. See the [Steering Committee Charter](charter.md) for
 specific committee structure information.
 
+### Term ends in October 2025
+
+| Name | Profile | Affiliation |
+| ---- | ------- | ----------- |
+| Maciej Szulik | **[@soltysh](https://github.com/soltysh)** | Red Hat |
+| Paco Xu 徐俊杰 | **[@pacoxu](https://github.com/pacoxu)** | DaoCloud |
+| Patrick Ohly | **[@pohly](https://github.com/pohly)** | Intel |
+| Stephen Augustus | **[@justaugustus](https://github.com/justaugustus)** | Cisco |
+
 ### Term ends in October 2024
 
 | Name | Profile | Affiliation |
@@ -13,15 +22,6 @@ specific committee structure information.
 | Benjamin Elder | **[@BenTheElder](https://github.com/bentheelder)** | Google |
 | Bob Killen | **[@mrbobbytables](https://github.com/mrbobbytables)** | Google |
 | Nabarun Pal | **[@palnabarun](https://github.com/palnabarun)** | VMware |
-
-### Term ends in October 2023
-
-| Name | Profile | Affiliation |
-| ---- | ------- | ----------- |
-| Christoph Blecker | **[@cblecker](https://github.com/cblecker)** | Red Hat |
-| Stephen Augustus | **[@justaugustus](https://github.com/justaugustus)** | Cisco |
-| Carlos Tadeu Panato Jr. | **[@cpanato](https://github.com/cpanato)**  |Chainguard |
-| Tim Pepper | **[@tpepper](https://github.com/tpepper)** | VMware |
 
 ### Emeritus
 
@@ -31,6 +31,8 @@ specific committee structure information.
 | Brandon Philips | **[@philips](https://github.com/philips)** |
 | Brendan Burns | **[@brendandburns](https://github.com/brendandburns)** |
 | Brian Grant | **[@bgrant0607](https://github.com/bgrant0607)** |
+| Carlos Tadeu Panato Jr. | **[@cpanato](https://github.com/cpanato)** |
+| Christoph Blecker | **[@cblecker](https://github.com/cblecker)** |
 | Clayton Coleman | **[@smarterclayton](https://github.com/smarterclayton)** |
 | Davanum Srinivas | **[@dims](https://github.com/dims)** |
 | Derek Carr | **[@derekwaynecarr](https://github.com/derekwaynecarr)** |
@@ -44,6 +46,7 @@ specific committee structure information.
 | Quinton Hoole | **[@quinton-hoole](https://github.com/quinton-hoole)** |
 | Sarah Novotny | **[@sarahnovotny](https://github.com/sarahnovotny)** |
 | Tim Hockin | **[@thockin](https://github.com/thockin)** |
+| Tim Pepper | **[@tpepper](https://github.com/tpepper)** |
 | Timothy St. Clair | **[@timothysc](https://github.com/timothysc)** |
 
 ## Meetings

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ specific committee structure information.
 
 | Name | Profile |
 | ---- | ------- |
-| Brian Grant | **[@bgrant0607](https://github.com/bgrant0607)** |
+| Aaron Crickenberger | **[@spiffxp](https://github.com/spiffxp)** |
+| Brandon Philips | **[@philips](https://github.com/philips)** |
 | Brendan Burns | **[@brendandburns](https://github.com/brendandburns)** |
+| Brian Grant | **[@bgrant0607](https://github.com/bgrant0607)** |
+| Clayton Coleman | **[@smarterclayton](https://github.com/smarterclayton)** |
 | Davanum Srinivas | **[@dims](https://github.com/dims)** |
 | Derek Carr | **[@derekwaynecarr](https://github.com/derekwaynecarr)** |
 | Joe Beda | **[@jbeda](https://github.com/jbeda)** |
@@ -37,12 +40,9 @@ specific committee structure information.
 | Michelle Noorali | **[@michelleN](https://github.com/michelleN)** |
 | Nikhita Raghunath | **[@nikhita](https://github.com/nikhita)** |
 | Paris Pittman | **[@parispittman](https://github.com/parispittman)** |
-| Brandon Philips | **[@philips](https://github.com/philips)** |
 | Phillip Wittrock | **[@pwittrock](https://github.com/pwittrock)** |
 | Quinton Hoole | **[@quinton-hoole](https://github.com/quinton-hoole)** |
 | Sarah Novotny | **[@sarahnovotny](https://github.com/sarahnovotny)** |
-| Clayton Coleman | **[@smarterclayton](https://github.com/smarterclayton)** |
-| Aaron Crickenberger | **[@spiffxp](https://github.com/spiffxp)** |
 | Tim Hockin | **[@thockin](https://github.com/thockin)** |
 | Timothy St. Clair | **[@timothysc](https://github.com/timothysc)** |
 


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

Add:

- Maciej Szulik - @soltysh
- Paco Xu 徐俊杰 - @pacoxu
- Patrick Ohly - @pohly

Now Emeritus:

- Carlos Tadeu Panato Jr. - @cpanato
- Christoph Blecker - @cblecker
- Tim Pepper - @tpepper

Thanks to all of the Emeritus members for your service and welcome to the new Steering Committee members!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @mrbobbytables @BenTheElder @palnabarun 
/cc @kubernetes/steering-committee 
/hold