### PR TITLE
Add sig-etcd to service desk list

### DIFF
--- a/operations/service-desk.md
+++ b/operations/service-desk.md
@@ -6,6 +6,7 @@ of the Kubernetes project.
 
 **Community Groups:**
 - [SIG Contributor Experience](https://git.k8s.io/community/sig-contributor-experience#leadership)
+- [SIG etcd](https://git.k8s.io/community/sig-etcd#leadership)
 - [SIG Release](https://git.k8s.io/community/sig-release#leadership)
 
 


### PR DESCRIPTION
Adding SIG etcd to the list of allowed SIGs that can have service desk accounts. The leads previously had it as maintainers of etcd, and still use it for some tasks.  In the future it may not be needed, but just want to cover the current status. :+1: 

/hold
/cc @jmhbnz @wenjiaswe @ahrtr @serathius 