### PR TITLE
Adding 2026 election officers

### DIFF
--- a/elections.md
+++ b/elections.md
@@ -136,6 +136,7 @@ History of election officers:
 - 2023: kaslin, dims, bridgetkromhout
 - 2024: bridgetkromhout, cblecker, Priyankasaggu11929
 - 2025: cblecker, npolshakova, sreeram-venkitesh
+- 2026: npolshakova, sreeram-venkitesh, reylejano
 
 ### Vacancies
 


### PR DESCRIPTION
Hey Steering friends, I noticed that https://github.com/kubernetes/steering/blob/main/elections.md did not yet have the 2026 Election Officers as listed in https://github.com/kubernetes/community/tree/main/elections/steering/2026#officers, so this PR corrects the record.